### PR TITLE
Simplify demographic audit report

### DIFF
--- a/tests/test_chronic_absenteeism_end_to_end.py
+++ b/tests/test_chronic_absenteeism_end_to_end.py
@@ -345,7 +345,7 @@ class TestChronicAbsenteeismEndToEnd:
         assert audit_file.exists(), "Demographic report should be created"
 
         content = audit_file.read_text()
-        assert "Mapping Log" in content
+        assert "Mapping Types" in content
         
         # Verify demographic standardization
         output_file = self.proc_dir / "chronic_absenteeism.csv"

--- a/tests/test_demographic_mapper.py
+++ b/tests/test_demographic_mapper.py
@@ -208,7 +208,7 @@ class TestDemographicMapperIntegration:
         if not audit_file.exists():
             pytest.skip("Demographic report not found. Run ETL pipeline first.")
         content = audit_file.read_text()
-        assert "Mapping Log" in content
+        assert "Mapping Types" in content
 
 
 class TestConvenienceFunctions:

--- a/tests/test_english_learner_progress_end_to_end.py
+++ b/tests/test_english_learner_progress_end_to_end.py
@@ -345,7 +345,7 @@ class TestEnglishLearnerProgressEndToEnd:
         assert audit_file.exists(), "Demographic report should be created"
 
         content = audit_file.read_text()
-        assert "Mapping Log" in content
+        assert "Mapping Types" in content
         
         # Verify demographic standardization
         output_file = self.proc_dir / "english_learner_progress.csv"

--- a/tests/test_safe_schools_events_end_to_end.py
+++ b/tests/test_safe_schools_events_end_to_end.py
@@ -412,7 +412,7 @@ class TestSafeSchoolsEventsEndToEnd:
         assert audit_file.exists(), "Demographic report should be created"
 
         content = audit_file.read_text()
-        assert 'Mapping Log' in content
+        assert 'Mapping Types' in content
 
         print(f"✅ Demographic mapping: {len(student_groups)} student groups")
     


### PR DESCRIPTION
## Summary
- reduce audit markdown size by only listing processed files and mapping summary
- adjust unit tests for new audit report format
- install pyarrow for parquet tests

## Testing
- `python3 -m pytest tests/test_demographic_mapper.py -v`
- `python3 -m pytest tests/test_chronic_absenteeism_end_to_end.py -v`
- `python3 -m pytest tests/test_english_learner_progress_end_to_end.py -v`
- `python3 -m pytest tests/test_safe_schools_events_end_to_end.py -v`
- `python3 -m pytest tests/ -v`
- `python3 etl_runner.py`

------
https://chatgpt.com/codex/tasks/task_e_687dc68c9d088330ba67acf82dbcf5d7