### PR TITLE
Add Kentucky Summative Assessment pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ Each directory includes detailed descriptions, file metadata, and direct downloa
   - Years: 2020-2024
   - All districts with demographic breakdowns
 
+- **Kentucky Summative Assessment** (`kentucky_summative_assessment.csv`)
+  - Performance levels and content index by subject with metrics for both grade and school level
+  - Years: 2021-2024
+  - All districts with demographic breakdowns
+
 - **Out-of-School Suspension** (`out_of_school_suspension.csv`)
   - Discipline action counts by type
   - Years: 2020-2023

--- a/config/demographic_mappings.yaml
+++ b/config/demographic_mappings.yaml
@@ -28,9 +28,14 @@ standard_demographics:
   - "Students without IEP"
   - "Military Dependent"
   - "Non-Military"
+  - "Non-Military Dependent"
   - "Gifted and Talented"
+  - "Non-Gifted and Talented"
   - "Consolidated Student Group"
   - "Alternate Assessment"
+  - "Students with Disabilities/IEP Regular Assessment"
+  - "Students with Disabilities/IEP with Accommodations"
+  - "Students with Disabilities/IEP without Accommodations"
 
 # General demographic mappings (case variations, common misspellings, etc.)
 mappings:
@@ -39,6 +44,11 @@ mappings:
   "Non English Learner": "Non-English Learner"
   "Non-Foster": "Non-Foster Care"
   "Student without Disabilities (IEP)": "Students without IEP"
+  "Students with Disabilities/IEP Regular Assessment": "Students with Disabilities (IEP)"
+  "Students with Disabilities/IEP with Accommodations": "Students with Disabilities (IEP)"
+  "Students with Disabilities/IEP without Accommodations": "Students with Disabilities (IEP)"
+  "Non-Gifted and Talented": "Non-Gifted and Talented"
+  "Non-Military Dependent": "Non-Military Dependent"
   
   # Historical format variations 
   "White (Non Hispanic)": "White (non-Hispanic)"
@@ -190,8 +200,13 @@ year_specific:
       - "Non-English Learner"
       - "Non-Economically Disadvantaged"
       - "Gifted and Talented"
+      - "Non-Gifted and Talented"
       - "Military Dependent"
       - "Non-Military"
+      - "Non-Military Dependent"
+      - "Students with Disabilities/IEP Regular Assessment"
+      - "Students with Disabilities/IEP with Accommodations"
+      - "Students with Disabilities/IEP without Accommodations"
     mappings:
       "Non Economically Disadvantaged": "Non-Economically Disadvantaged"
       "Non English Learner": "Non-English Learner"
@@ -228,6 +243,11 @@ validation:
     - "Non-Homeless"                         # 2024 only
     - "Non-Migrant"                          # 2024 only
     - "Non-Military"                         # 2024 only
+    - "Non-Military Dependent"               # 2024 only
+    - "Non-Gifted and Talented"              # 2024 only
+    - "Students with Disabilities/IEP Regular Assessment"  # 2024 only
+    - "Students with Disabilities/IEP with Accommodations"  # 2024 only
+    - "Students with Disabilities/IEP without Accommodations"  # 2024 only
     - "Non-Economically Disadvantaged"      # Present in all years but not critical
     - "Non-English Learner"                 # Present in all years but not critical
     - "Non-Foster Care"                      # Present in all years but not critical

--- a/config/demographic_mappings.yaml
+++ b/config/demographic_mappings.yaml
@@ -44,9 +44,9 @@ mappings:
   "Non English Learner": "Non-English Learner"
   "Non-Foster": "Non-Foster Care"
   "Student without Disabilities (IEP)": "Students without IEP"
-  "Students with Disabilities/IEP Regular Assessment": "Students with Disabilities (IEP)"
-  "Students with Disabilities/IEP with Accommodations": "Students with Disabilities (IEP)"
-  "Students with Disabilities/IEP without Accommodations": "Students with Disabilities (IEP)"
+  "Students with Disabilities/IEP Regular Assessment": "Students with Disabilities/IEP Regular Assessment"
+  "Students with Disabilities/IEP with Accommodations": "Students with Disabilities/IEP with Accommodations"
+  "Students with Disabilities/IEP without Accommodations": "Students with Disabilities/IEP without Accommodations"
   "Non-Gifted and Talented": "Non-Gifted and Talented"
   "Non-Military Dependent": "Non-Military Dependent"
   

--- a/etl/base_etl.py
+++ b/etl/base_etl.py
@@ -340,7 +340,10 @@ class BaseETL(ABC):
             'Preschool': 'preschool'
         }
         
-        df['grade'] = df['grade'].map(grade_mapping).fillna(df['grade'].str.lower().str.replace(' ', '_'))
+        df['grade'] = df['grade'].astype(str)
+        df['grade'] = df['grade'].map(grade_mapping).fillna(
+            df['grade'].str.lower().str.replace(' ', '_')
+        )
         
         return df
     

--- a/etl/kentucky_summative_assessment.py
+++ b/etl/kentucky_summative_assessment.py
@@ -1,0 +1,191 @@
+"""Kentucky Summative Assessment ETL module."""
+from pathlib import Path
+from typing import Dict, Any, Union
+import pandas as pd
+import logging
+import sys
+from pydantic import BaseModel
+
+etl_dir = Path(__file__).parent
+sys.path.insert(0, str(etl_dir))
+
+from base_etl import BaseETL
+
+logger = logging.getLogger(__name__)
+
+
+class Config(BaseModel):
+    rename: Dict[str, str] = {}
+    dtype: Dict[str, str] = {}
+    derive: Dict[str, Union[str, int, float]] = {}
+
+
+class KentuckySummativeAssessmentETL(BaseETL):
+    """ETL for processing Kentucky Summative Assessment data."""
+
+    @property
+    def module_column_mappings(self) -> Dict[str, str]:
+        return {
+            'Level': 'level',
+            'LEVEL': 'level',
+            'Subject': 'subject',
+            'SUBJECT': 'subject',
+            'Novice': 'novice',
+            'NOVICE': 'novice',
+            'Apprentice': 'apprentice',
+            'APPRENTICE': 'apprentice',
+            'Proficient': 'proficient',
+            'PROFICIENT': 'proficient',
+            'Distinguished': 'distinguished',
+            'DISTINGUISHED': 'distinguished',
+            'Proficient / Distinguished': 'proficient_distinguished',
+            'PROFICIENT/DISTINGUISHED': 'proficient_distinguished',
+            'Content Index': 'content_index',
+            'CONTENT INDEX': 'content_index',
+        }
+
+    def _normalize_subject(self, value: Any) -> str:
+        mapping = {
+            'MA': 'math',
+            'Mathematics': 'math',
+            'RD': 'reading',
+            'Reading': 'reading',
+            'SC': 'science',
+            'Science': 'science',
+            'SS': 'social_studies',
+            'Social Studies': 'social_studies',
+            'WR': 'writing',
+            'Writing': 'writing',
+        }
+        if value is None or pd.isna(value) or value == '':
+            return 'unknown_subject'
+        val = str(value).strip()
+        return mapping.get(val, val.lower().replace(' ', '_'))
+
+    def _normalize_grade(self, grade: Any) -> str:
+        if grade is None or pd.isna(grade) or str(grade).strip() == '':
+            return 'all_grades'
+        g = str(grade).strip()
+        if g.isdigit():
+            return f'grade_{int(g)}'
+        if g.lower().startswith('grade '):
+            return g.lower().replace('grade ', 'grade_')
+        return g.lower().replace(' ', '_')
+
+    def _normalize_level(self, level: Any) -> str:
+        mapping = {
+            'ES': 'elementary',
+            'MS': 'middle',
+            'HS': 'high',
+            'Elementary School': 'elementary',
+            'Middle School': 'middle',
+            'High School': 'high',
+            'Elementary': 'elementary',
+            'Middle': 'middle',
+            'High': 'high',
+        }
+        if level is None or pd.isna(level) or str(level).strip() == '':
+            return 'all'
+        lv = str(level).strip()
+        return mapping.get(lv, lv.lower().replace(' ', '_'))
+
+    def _grade_to_level(self, grade: str) -> str:
+        if grade.startswith('grade_'):
+            try:
+                num = int(grade.split('_')[1])
+                if num >= 9:
+                    return 'high'
+                if num >= 6:
+                    return 'middle'
+                return 'elementary'
+            except ValueError:
+                return 'all'
+        if grade in {'kindergarten', 'pre_k', 'preschool'}:
+            return 'elementary'
+        return 'all'
+
+    def extract_metrics(self, row: pd.Series) -> Dict[str, Any]:
+        subject = self._normalize_subject(row.get('subject'))
+        grade_period = self._normalize_grade(row.get('grade'))
+        level_period = self._normalize_level(row.get('level'))
+        if level_period == 'all' and grade_period != 'all_grades':
+            level_period = self._grade_to_level(grade_period)
+
+        metrics: Dict[str, Any] = {}
+
+        def add(name: str, value: Any) -> None:
+            if pd.notna(value):
+                for period in {grade_period, level_period}:
+                    if period == 'all' or period == 'all_grades':
+                        continue
+                    try:
+                        metrics[f'{subject}_{name}_{period}'] = float(value)
+                    except (ValueError, TypeError):
+                        metrics[f'{subject}_{name}_{period}'] = pd.NA
+
+        add('novice_rate', row.get('novice'))
+        add('apprentice_rate', row.get('apprentice'))
+        add('proficient_rate', row.get('proficient'))
+        add('distinguished_rate', row.get('distinguished'))
+        add('proficient_distinguished_rate', row.get('proficient_distinguished'))
+        if 'content_index' in row:
+            add('content_index_score', row.get('content_index'))
+
+        return metrics
+
+    def get_suppressed_metric_defaults(self, row: pd.Series) -> Dict[str, Any]:
+        subject = self._normalize_subject(row.get('subject'))
+        grade_period = self._normalize_grade(row.get('grade'))
+        level_period = self._normalize_level(row.get('level'))
+        if level_period == 'all' and grade_period != 'all_grades':
+            level_period = self._grade_to_level(grade_period)
+
+        metrics: Dict[str, Any] = {}
+
+        for period in {grade_period, level_period}:
+            if period == 'all' or period == 'all_grades':
+                continue
+            metrics[f'{subject}_novice_rate_{period}'] = pd.NA
+            metrics[f'{subject}_apprentice_rate_{period}'] = pd.NA
+            metrics[f'{subject}_proficient_rate_{period}'] = pd.NA
+            metrics[f'{subject}_distinguished_rate_{period}'] = pd.NA
+            metrics[f'{subject}_proficient_distinguished_rate_{period}'] = pd.NA
+            if 'content_index' in row:
+                metrics[f'{subject}_content_index_score_{period}'] = pd.NA
+
+        return metrics
+
+    def standardize_missing_values(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = super().standardize_missing_values(df)
+        numeric_cols = [
+            'novice',
+            'apprentice',
+            'proficient',
+            'distinguished',
+            'proficient_distinguished',
+            'content_index',
+        ]
+        for col in numeric_cols:
+            if col in df.columns:
+                df[col] = pd.to_numeric(df[col], errors='coerce')
+                invalid = (df[col] < 0) | (df[col] > 100)
+                if invalid.any():
+                    logger.warning(
+                        f'Found {invalid.sum()} invalid values in {col}'
+                    )
+                    df.loc[invalid, col] = pd.NA
+        return df
+
+def transform(raw_dir: Path, proc_dir: Path, cfg: dict) -> None:
+    """Entry point for pipeline."""
+    etl = KentuckySummativeAssessmentETL('kentucky_summative_assessment')
+    etl.transform(raw_dir, proc_dir, cfg)
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    root = Path(__file__).parent.parent
+    raw_dir = root / 'data' / 'raw'
+    proc_dir = root / 'data' / 'processed'
+    proc_dir.mkdir(exist_ok=True)
+    transform(raw_dir, proc_dir, {'derive': {}})

--- a/notes/39--kentucky-summative-assessment-pipeline-implementation.md
+++ b/notes/39--kentucky-summative-assessment-pipeline-implementation.md
@@ -1,0 +1,14 @@
+# 39 - Kentucky Summative Assessment Pipeline Implementation
+
+**Date**: 2025-07-22
+
+## Overview
+Implemented a new ETL pipeline to process Kentucky Summative Assessment (KSA) files. Added raw data preparation via the existing downloader and created unit and integration tests.
+
+## Key Points
+- Mapped multiple KSA file formats (2023-2024) to common columns.
+- Normalized subject and grade/level values for metric naming.
+- Created metrics for each performance level and content index.
+- Output metrics by both grade and school level for cross-year consistency.
+- Added unit tests and end-to-end test verifying KPI output.
+- Installed missing dependencies (`ruamel.yaml`, `tabulate`).

--- a/tests/test_kentucky_summative_assessment.py
+++ b/tests/test_kentucky_summative_assessment.py
@@ -1,0 +1,116 @@
+"""Tests for Kentucky Summative Assessment ETL module"""
+import shutil
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from etl.kentucky_summative_assessment import (
+    KentuckySummativeAssessmentETL,
+    transform,
+)
+
+
+class TestKentuckySummativeAssessmentETL:
+    def setup_method(self):
+        self.test_dir = Path(tempfile.mkdtemp())
+        self.raw_dir = self.test_dir / "raw"
+        self.proc_dir = self.test_dir / "processed"
+        self.proc_dir.mkdir(parents=True)
+        self.sample_dir = self.raw_dir / "kentucky_summative_assessment"
+        self.sample_dir.mkdir(parents=True)
+        self.etl = KentuckySummativeAssessmentETL("kentucky_summative_assessment")
+
+    def teardown_method(self):
+        shutil.rmtree(self.test_dir)
+
+    def create_sample_2024_data(self):
+        return pd.DataFrame({
+            "School Year": ["20232024"],
+            "County Name": ["ADAIR"],
+            "District Name": ["Adair County"],
+            "School Name": ["All Schools"],
+            "School Code": ["001000"],
+            "Level": ["Elementary School"],
+            "Subject": ["Mathematics"],
+            "Demographic": ["All Students"],
+            "Suppressed": ["N"],
+            "Novice": [28],
+            "Apprentice": [32],
+            "Proficient": [31],
+            "Distinguished": [10],
+            "Proficient / Distinguished": [41],
+            "Content Index": [58.7],
+        })
+
+    def create_sample_2023_data(self):
+        return pd.DataFrame({
+            "SCHOOL YEAR": ["20222023"],
+            "COUNTY NAME": ["ADAIR"],
+            "DISTRICT NAME": ["Adair County"],
+            "SCHOOL NAME": ["All Schools"],
+            "SCHOOL CODE": ["001000"],
+            "GRADE": ["03"],
+            "SUBJECT": ["MA"],
+            "DEMOGRAPHIC": ["All Students"],
+            "SUPPRESSED": ["N"],
+            "NOVICE": [28],
+            "APPRENTICE": [42],
+            "PROFICIENT": [22],
+            "DISTINGUISHED": [7],
+            "PROFICIENT/DISTINGUISHED": [29],
+        })
+
+    def test_normalize_column_names(self):
+        df = self.create_sample_2024_data()
+        normalized = self.etl.normalize_column_names(df)
+        assert "subject" in normalized.columns
+        assert "novice" in normalized.columns
+
+    def test_extract_metrics(self):
+        df = self.create_sample_2024_data()
+        df = self.etl.normalize_column_names(df)
+        row = df.iloc[0]
+        metrics = self.etl.extract_metrics(row)
+        assert metrics["math_novice_rate_elementary"] == 28.0
+        assert metrics["math_content_index_score_elementary"] == 58.7
+
+    def test_convert_to_kpi_format(self):
+        df = self.create_sample_2024_data()
+        df = self.etl.normalize_column_names(df)
+        df = self.etl.standardize_missing_values(df)
+        df["source_file"] = "test.csv"
+        kpi = self.etl.convert_to_kpi_format(df, "test.csv")
+        assert not kpi.empty
+        assert set(kpi["metric"].unique()) == {
+            "math_novice_rate_elementary",
+            "math_apprentice_rate_elementary",
+            "math_proficient_rate_elementary",
+            "math_distinguished_rate_elementary",
+            "math_proficient_distinguished_rate_elementary",
+            "math_content_index_score_elementary",
+        }
+
+    def test_full_transform_pipeline(self):
+        df = self.create_sample_2024_data()
+        sample_file = self.sample_dir / "sample.csv"
+        df.to_csv(sample_file, index=False)
+        transform(self.raw_dir, self.proc_dir, {"derive": {}})
+        output = self.proc_dir / "kentucky_summative_assessment.csv"
+        assert output.exists()
+        out_df = pd.read_csv(output)
+        assert not out_df.empty
+
+    def test_grade_and_level_metrics(self):
+        df_level = self.create_sample_2024_data()
+        df_grade = self.create_sample_2023_data()
+        df_level.to_csv(self.sample_dir / "level.csv", index=False)
+        df_grade.to_csv(self.sample_dir / "grade.csv", index=False)
+        transform(self.raw_dir, self.proc_dir, {"derive": {}})
+        output = self.proc_dir / "kentucky_summative_assessment.csv"
+        assert output.exists()
+        out_df = pd.read_csv(output)
+        metrics = out_df["metric"].unique()
+        assert any(m.endswith("elementary") for m in metrics)
+        assert any("grade_3" in m for m in metrics)

--- a/tests/test_kentucky_summative_assessment_end_to_end.py
+++ b/tests/test_kentucky_summative_assessment_end_to_end.py
@@ -1,0 +1,82 @@
+"""End-to-end tests for Kentucky Summative Assessment pipeline"""
+import shutil
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from etl.kentucky_summative_assessment import transform
+
+
+class TestKentuckySummativeAssessmentEndToEnd:
+    def setup_method(self):
+        self.test_dir = Path(tempfile.mkdtemp())
+        self.raw_dir = self.test_dir / "raw"
+        self.proc_dir = self.test_dir / "processed"
+        self.proc_dir.mkdir(parents=True)
+        self.sample_dir = self.raw_dir / "kentucky_summative_assessment"
+        self.sample_dir.mkdir(parents=True)
+
+    def teardown_method(self):
+        shutil.rmtree(self.test_dir)
+
+    def create_data(self):
+        return pd.DataFrame({
+            "School Year": ["20232024", "20232024"],
+            "County Name": ["ADAIR", "ADAIR"],
+            "District Name": ["Adair County", "Adair County"],
+            "School Name": ["All Schools", "All Schools"],
+            "School Code": ["001000", "001000"],
+            "Level": ["Elementary School", "Elementary School"],
+            "Subject": ["Mathematics", "Mathematics"],
+            "Demographic": ["All Students", "Hispanic"],
+            "Suppressed": ["N", "Y"],
+            "Novice": [28, "*"],
+            "Apprentice": [32, "*"],
+            "Proficient": [31, "*"],
+            "Distinguished": [10, "*"],
+            "Proficient / Distinguished": [41, "*"],
+            "Content Index": [58.7, "*"],
+        })
+
+    def create_grade_data(self):
+        return pd.DataFrame({
+            "SCHOOL YEAR": ["20222023"],
+            "COUNTY NAME": ["ADAIR"],
+            "DISTRICT NAME": ["Adair County"],
+            "SCHOOL NAME": ["All Schools"],
+            "SCHOOL CODE": ["001000"],
+            "GRADE": ["03"],
+            "SUBJECT": ["MA"],
+            "DEMOGRAPHIC": ["All Students"],
+            "SUPPRESSED": ["N"],
+            "NOVICE": [28],
+            "APPRENTICE": [32],
+            "PROFICIENT": [31],
+            "DISTINGUISHED": [10],
+            "PROFICIENT/DISTINGUISHED": [41],
+        })
+
+    def test_end_to_end(self):
+        df = self.create_data()
+        sample_file = self.sample_dir / "sample.csv"
+        df.to_csv(sample_file, index=False)
+        transform(self.raw_dir, self.proc_dir, {"derive": {}})
+        output = self.proc_dir / "kentucky_summative_assessment.csv"
+        assert output.exists()
+        df_out = pd.read_csv(output)
+        assert not df_out.empty
+        assert set(df_out["suppressed"].unique()).issubset({"Y", "N"})
+
+    def test_grade_and_level(self):
+        df_level = self.create_data().head(1)
+        df_grade = self.create_grade_data()
+        df_level.to_csv(self.sample_dir / "level.csv", index=False)
+        df_grade.to_csv(self.sample_dir / "grade.csv", index=False)
+        transform(self.raw_dir, self.proc_dir, {"derive": {}})
+        output = self.proc_dir / "kentucky_summative_assessment.csv"
+        assert output.exists()
+        df_out = pd.read_csv(output)
+        metrics = df_out["metric"].unique()
+        assert any("grade_3" in m for m in metrics)
+        assert any(m.endswith("elementary") for m in metrics)


### PR DESCRIPTION
## Summary
- prepare raw data for the KSA pipeline
- implement `kentucky_summative_assessment` ETL module
- add unit and E2E tests
- document the pipeline and update README
- add missing demographic categories to mapper to reduce warnings

## Testing
- `python3 -m py_compile etl/kentucky_summative_assessment.py`
- `python3 -m pytest tests/test_kentucky_summative_assessment.py -v`
- `python3 -m pytest tests/test_kentucky_summative_assessment_end_to_end.py -v`
- `python3 -m pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_687eeccde98883308ef3b17a91b75ad7