### PR TITLE
Add journal entry reviewing postsecondary enrollment KPI mapping

### DIFF
--- a/etl/postsecondary_enrollment.py
+++ b/etl/postsecondary_enrollment.py
@@ -70,34 +70,34 @@ class PostsecondaryEnrollmentETL(BaseETL):
 
     def extract_metrics(self, row: pd.Series) -> Dict[str, Any]:
         metrics = {}
-        metrics["postsecondary_enrollment_total_cohort"] = row.get("total_in_group")
-        metrics["postsecondary_enrollment_public_count"] = row.get(
+        metrics["postsecondary_enrollment_total_in_cohort"] = row.get("total_in_group")
+        metrics["postsecondary_enrollment_public_ky_college_count"] = row.get(
             "public_college_enrolled"
         )
-        metrics["postsecondary_enrollment_private_count"] = row.get(
+        metrics["postsecondary_enrollment_private_ky_college_count"] = row.get(
             "private_college_enrolled"
         )
-        metrics["postsecondary_enrollment_total_count"] = row.get(
+        metrics["postsecondary_enrollment_total_ky_college_count"] = row.get(
             "college_enrolled_total"
         )
-        metrics["postsecondary_enrollment_public_rate"] = row.get("public_college_rate")
-        metrics["postsecondary_enrollment_private_rate"] = row.get(
+        metrics["postsecondary_enrollment_public_ky_college_rate"] = row.get("public_college_rate")
+        metrics["postsecondary_enrollment_private_ky_college_rate"] = row.get(
             "private_college_rate"
         )
-        metrics["postsecondary_enrollment_total_rate"] = row.get(
+        metrics["postsecondary_enrollment_total_ky_college_rate"] = row.get(
             "college_enrollment_rate"
         )
         return metrics
 
     def get_suppressed_metric_defaults(self, row: pd.Series) -> Dict[str, Any]:
         return {
-            "postsecondary_enrollment_total_cohort": pd.NA,
-            "postsecondary_enrollment_public_count": pd.NA,
-            "postsecondary_enrollment_private_count": pd.NA,
-            "postsecondary_enrollment_total_count": pd.NA,
-            "postsecondary_enrollment_public_rate": pd.NA,
-            "postsecondary_enrollment_private_rate": pd.NA,
-            "postsecondary_enrollment_total_rate": pd.NA,
+            "postsecondary_enrollment_total_in_cohort": pd.NA,
+            "postsecondary_enrollment_public_ky_college_count": pd.NA,
+            "postsecondary_enrollment_private_ky_college_count": pd.NA,
+            "postsecondary_enrollment_total_ky_college_count": pd.NA,
+            "postsecondary_enrollment_public_ky_college_rate": pd.NA,
+            "postsecondary_enrollment_private_ky_college_rate": pd.NA,
+            "postsecondary_enrollment_total_ky_college_rate": pd.NA,
         }
 
     def standardize_missing_values(self, df: pd.DataFrame) -> pd.DataFrame:

--- a/html/equity_dashboard.html
+++ b/html/equity_dashboard.html
@@ -236,9 +236,9 @@
                 'kindergarten_readiness_rate': 'Kindergarten Readiness Rate',
                 'postsecondary_readiness_rate': 'Postsecondary Readiness Rate',
                 'postsecondary_readiness_rate_with_bonus': 'Postsecondary Readiness Rate (With Bonus)',
-                'postsecondary_enrollment_public_rate': 'Public College Enrollment Rate',
-                'postsecondary_enrollment_private_rate': 'Private College Enrollment Rate',
-                'postsecondary_enrollment_total_rate': 'Total College Enrollment Rate',
+                'postsecondary_enrollment_public_ky_college_rate': 'Public College Enrollment Rate',
+                'postsecondary_enrollment_private_ky_college_rate': 'Private College Enrollment Rate',
+                'postsecondary_enrollment_total_ky_college_rate': 'Total College Enrollment Rate',
                 'out_of_school_suspension_single_total_count': 'Single Out-of-School Suspensions (Total)',
                 'out_of_school_suspension_multiple_total_count': 'Multiple Out-of-School Suspensions (Total)',
                 'out_of_school_suspension_total_count': 'Out-of-School Suspensions (All Types)'

--- a/notes/40--postsecondary-enrollment-kpi-review.md
+++ b/notes/40--postsecondary-enrollment-kpi-review.md
@@ -1,0 +1,35 @@
+# Postsecondary Enrollment KPI Review
+
+## Overview
+Investigated how `etl/postsecondary_enrollment.py` generates current KPIs from the raw Kentucky Department of Education files. The pipeline uses `BaseETL` to standardize columns and metrics.
+
+## KPI Mapping
+- **total_in_cohort** → derived from `Total In Group`
+- **public_ky_college_count** → from `Public College Enrolled In State`
+- **private_ky_college_count** → from `Private College Enrolled In State`
+- **total_ky_college_count** → from `College Enrolled In State`
+- **public_ky_college_rate** → from `Percentage Public College Enrolled In State`
+- **private_ky_college_rate** → from `Percentage Private College Enrolled In State`
+- **total_ky_college_rate** → from `Percentage College Enrolled In State`
+
+Mapping occurs in `module_column_mappings` and `extract_metrics`:
+```
+metrics["postsecondary_enrollment_total_in_cohort"] = row.get("total_in_group")
+metrics["postsecondary_enrollment_public_ky_college_count"] = row.get("public_college_enrolled")
+metrics["postsecondary_enrollment_private_ky_college_count"] = row.get("private_college_enrolled")
+metrics["postsecondary_enrollment_total_ky_college_count"] = row.get("college_enrolled_total")
+metrics["postsecondary_enrollment_public_ky_college_rate"] = row.get("public_college_rate")
+metrics["postsecondary_enrollment_private_ky_college_rate"] = row.get("private_college_rate")
+metrics["postsecondary_enrollment_total_ky_college_rate"] = row.get("college_enrollment_rate")
+```
+
+## Potential Additional Metrics
+The source files appear to only include in-state public/private counts and rates. However we could derive new KPIs:
+1. **Non-enrollment count** = `total_in_cohort - total_ky_college_count`
+2. **Non-enrollment rate** = `100 - total_ky_college_rate`
+
+If future files include out-of-state enrollment or 2-year/4-year splits, those could be added similarly.
+
+## Next Steps
+- Confirm whether raw files contain additional columns (e.g., out-of-state or institution type) not currently mapped.
+- If available, extend the pipeline to generate complementary KPIs like non-enrollment metrics.

--- a/tests/test_postsecondary_enrollment.py
+++ b/tests/test_postsecondary_enrollment.py
@@ -62,7 +62,7 @@ class TestPostsecondaryEnrollmentETL:
         df["source_file"] = "test.csv"
         kpi = self.etl.convert_to_kpi_format(df, "test.csv")
         metrics = set(kpi["metric"].unique())
-        assert "postsecondary_enrollment_total_rate" in metrics
+        assert "postsecondary_enrollment_total_ky_college_rate" in metrics
         assert len(kpi) == 7
 
     def test_transform_integration(self):

--- a/tests/test_postsecondary_enrollment_end_to_end.py
+++ b/tests/test_postsecondary_enrollment_end_to_end.py
@@ -41,12 +41,12 @@ class TestPostsecondaryEnrollmentE2E:
         df = pd.read_csv(out_file)
         assert len(df) == 7
         assert set(df["metric"].unique()) == {
-            "postsecondary_enrollment_total_cohort",
-            "postsecondary_enrollment_public_count",
-            "postsecondary_enrollment_private_count",
-            "postsecondary_enrollment_total_count",
-            "postsecondary_enrollment_public_rate",
-            "postsecondary_enrollment_private_rate",
-            "postsecondary_enrollment_total_rate",
+            "postsecondary_enrollment_total_in_cohort",
+            "postsecondary_enrollment_public_ky_college_count",
+            "postsecondary_enrollment_private_ky_college_count",
+            "postsecondary_enrollment_total_ky_college_count",
+            "postsecondary_enrollment_public_ky_college_rate",
+            "postsecondary_enrollment_private_ky_college_rate",
+            "postsecondary_enrollment_total_ky_college_rate",
         }
 


### PR DESCRIPTION
## Summary
- document how the postsecondary enrollment pipeline maps columns to KPIs
- note potential future KPIs that could be derived from the same data
- rename all postsecondary enrollment KPIs to use *_ky_college_* pattern
- update dashboard metric display and tests

## Testing
- `python3 data/prepare_kde_data.py postsecondary_enrollment`
- `python3 etl/postsecondary_enrollment.py`
- `python3 -m pytest tests/test_postsecondary_enrollment.py -v`
- `python3 -m pytest tests/test_postsecondary_enrollment_end_to_end.py -v`
- `python3 -m pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_68802e6a147083309140a957b8a7702e