### PR TITLE
Add counts for additional safe schools metrics

### DIFF
--- a/etl/out_of_school_suspension.py
+++ b/etl/out_of_school_suspension.py
@@ -46,17 +46,29 @@ class OutOfSchoolSuspensionETL(BaseETL):
         }
 
     def _numeric_clean(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Remove commas and convert numeric columns to numbers."""
-        numeric_cols = [c for c in df.columns if 'out_of_school' in c.lower()]
+        """Remove commas and convert numeric columns to numeric types."""
+        numeric_keywords = [
+            'out_of_school',
+            'in_school',
+            'expelled',
+            'corporal_punishment',
+            'restraint',
+            'seclusion',
+            'unilateral_removal',
+            'removal_by_hearing_officer',
+            'total_discipline_resolutions',
+        ]
+        numeric_cols = [
+            c for c in df.columns if any(k in c.lower() for k in numeric_keywords)
+        ]
         for col in numeric_cols:
-            if col in df.columns:
-                df[col] = (
-                    df[col]
-                    .astype(str)
-                    .str.replace(',', '')
-                    .replace('nan', pd.NA)
-                )
-                df[col] = pd.to_numeric(df[col], errors='coerce')
+            df[col] = (
+                df[col]
+                .astype(str)
+                .str.replace(',', '')
+                .replace('nan', pd.NA)
+            )
+            df[col] = pd.to_numeric(df[col], errors='coerce')
         return df
 
     def standardize_missing_values(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -102,11 +114,36 @@ class OutOfSchoolSuspensionETL(BaseETL):
             metrics = {
                 'out_of_school_suspension_count': row.get('out_of_school_suspension')
             }
+
+        # Additional counts available in both formats
+        in_swd = row.get('in_school_with_disabilities') if 'in_school_with_disabilities' in row.index else None
+        in_swod = row.get('in_school_without_disabilities') if 'in_school_without_disabilities' in row.index else None
+        if 'in_school_with_disabilities' in row.index or 'in_school_without_disabilities' in row.index:
+            metrics['in_school_suspension_with_disabilities_count'] = in_swd
+            metrics['in_school_suspension_without_disabilities_count'] = in_swod
+            ins_total = sum(v for v in [in_swd, in_swod] if pd.notna(v))
+            metrics['in_school_suspension_total_count'] = ins_total
+
+        count_map = {
+            'expelled_receiving_services': 'expelled_receiving_services_count',
+            'expelled_not_receiving_services': 'expelled_not_receiving_services_count',
+            'corporal_punishment': 'corporal_punishment_count',
+            'in_school_removal': 'in_school_removal_count',
+            'restraint': 'restraint_count',
+            'seclusion': 'seclusion_count',
+            'unilateral_removal': 'unilateral_removal_count',
+            'removal_by_hearing_officer': 'removal_by_hearing_officer_count',
+            'total_discipline_resolutions': 'discipline_resolution_total_count',
+        }
+        for src, metric_name in count_map.items():
+            if src in row.index:
+                metrics[metric_name] = row.get(src)
+
         return metrics
 
     def get_suppressed_metric_defaults(self, row: pd.Series) -> Dict[str, Any]:
         if 'single_out_of_school_with_disabilities' in row.index:
-            return {
+            defaults = {
                 'out_of_school_suspension_single_with_disabilities_count': pd.NA,
                 'out_of_school_suspension_single_without_disabilities_count': pd.NA,
                 'out_of_school_suspension_multiple_with_disabilities_count': pd.NA,
@@ -115,7 +152,28 @@ class OutOfSchoolSuspensionETL(BaseETL):
                 'out_of_school_suspension_multiple_total_count': pd.NA,
                 'out_of_school_suspension_total_count': pd.NA,
             }
-        return {'out_of_school_suspension_count': pd.NA}
+        else:
+            defaults = {'out_of_school_suspension_count': pd.NA}
+
+        extra_defaults = [
+            'in_school_suspension_with_disabilities_count',
+            'in_school_suspension_without_disabilities_count',
+            'in_school_suspension_total_count',
+            'expelled_receiving_services_count',
+            'expelled_not_receiving_services_count',
+            'corporal_punishment_count',
+            'in_school_removal_count',
+            'restraint_count',
+            'seclusion_count',
+            'unilateral_removal_count',
+            'removal_by_hearing_officer_count',
+            'discipline_resolution_total_count',
+        ]
+
+        for metric in extra_defaults:
+            defaults[metric] = pd.NA
+
+        return defaults
 
     def convert_to_kpi_format(self, df: pd.DataFrame, source_file: str) -> pd.DataFrame:
         """Override to apply metric-level suppression handling."""

--- a/notes/40--out-of-school-suspension-kpi-mapping-review.md
+++ b/notes/40--out-of-school-suspension-kpi-mapping-review.md
@@ -1,0 +1,32 @@
+# Out-of-School Suspension KPI Mapping Review
+
+## Date: 2025-07-23
+
+## Overview
+Summarized how `etl/out_of_school_suspension.py` derives KPIs from source columns and identified unused data that could support additional metrics.
+
+## Current KPI Generation
+- **KYRC24 Format** (`KYRC24_OVW_Student_Suspensions.csv`)
+  - `Single Out-of-School With Disabilities` → `out_of_school_suspension_single_with_disabilities_count`
+  - `Single Out-of-School Without Disabilities` → `out_of_school_suspension_single_without_disabilities_count`
+  - `Multiple Out-of-School With Disabilities` → `out_of_school_suspension_multiple_with_disabilities_count`
+  - `Multiple Out-of-School Without Disabilities` → `out_of_school_suspension_multiple_without_disabilities_count`
+  - Single + Multiple totals are summed to create `*_single_total_count`, `*_multiple_total_count`, and `out_of_school_suspension_total_count`.
+- **Historical Safe Schools Format** (`safe_schools_discipline_[year].csv`)
+  - `OUT OF SCHOOL SUSPENSION SSP3` → `out_of_school_suspension_count`
+- Suppression logic marks rows as suppressed when all out-of-school columns are missing.
+
+## Unused Source Columns
+The column mapping table exposes several fields not currently transformed into KPIs:
+- In-school suspension counts (`In-School With Disabilities`, `In-School Without Disabilities`)
+- Discipline resolution counts (`Expelled Receiving Services SSP1`, `Expelled Not Receiving Services SSP2`, `Corporal Punishment SSP5`, `In-School Removal INSR`, `Restraint SSP7`, `Seclusion SSP8`, `Unilateral Removal by School Personnel IAES1`, `Removal by Hearing Officer IAES2`)
+- `Total Discipline Resolutions` (could be used for rate calculations)
+
+These are leveraged by the separate `safe_schools_discipline` pipeline to produce rates, but raw counts are not output anywhere.
+
+## Potential Additional KPIs
+1. **In-School Suspension Counts** – capturing totals by disability status could provide complementary context to out-of-school counts.
+2. **Expulsion and Removal Counts** – direct counts for expulsions or removals might be valuable alongside the rate metrics currently produced in the discipline pipeline.
+3. **Discipline Resolution Totals** – publishing total resolution counts would enable independent rate calculations or trend analysis outside the ETL.
+
+Adding these metrics would require extending either this pipeline or the safe schools discipline pipeline, ensuring adherence to the existing naming convention (`{indicator}_count`).

--- a/notes/41--out-of-school-suspension-additional-metrics.md
+++ b/notes/41--out-of-school-suspension-additional-metrics.md
@@ -1,0 +1,16 @@
+# Out-of-School Suspension Additional Metrics Implementation
+
+## Date: 2025-07-23
+
+## Overview
+Implemented new KPI outputs in the `out_of_school_suspension` pipeline to capture
+additional counts present in the raw Safe Schools discipline data. Added unit and
+end-to-end tests verifying the new metrics.
+
+## Key Changes
+- Numeric cleaning now handles in-school suspension, expulsion, and discipline
+  resolution fields.
+- `extract_metrics` emits counts for in-school suspensions, expulsions, removals,
+  and total discipline resolutions when columns are present.
+- Suppression defaults include these new metrics.
+- Tests updated to cover additional metric extraction and end-to-end generation.

--- a/tests/test_out_of_school_suspension.py
+++ b/tests/test_out_of_school_suspension.py
@@ -63,6 +63,22 @@ class TestOutOfSchoolSuspensionETL:
         assert kpi['suppressed'].iloc[0] == 'Y'
         assert pd.isna(kpi['value'].iloc[0])
 
+    def test_extract_metrics_additional_counts(self):
+        row = pd.Series({
+            'single_out_of_school_with_disabilities': 1,
+            'single_out_of_school_without_disabilities': 2,
+            'multiple_out_of_school_with_disabilities': 0,
+            'multiple_out_of_school_without_disabilities': 1,
+            'in_school_with_disabilities': 3,
+            'in_school_without_disabilities': 4,
+            'expelled_receiving_services': 1,
+            'total_discipline_resolutions': 10
+        })
+        metrics = self.etl.extract_metrics(row)
+        assert metrics['in_school_suspension_total_count'] == 7
+        assert metrics['expelled_receiving_services_count'] == 1
+        assert metrics['discipline_resolution_total_count'] == 10
+
 
 class TestTransform:
     def test_transform_creates_files(self):

--- a/tests/test_out_of_school_suspension_end_to_end.py
+++ b/tests/test_out_of_school_suspension_end_to_end.py
@@ -23,7 +23,11 @@ class TestOutOfSchoolSuspensionE2E:
                 'Single Out-of-School With Disabilities': [1],
                 'Single Out-of-School Without Disabilities': [2],
                 'Multiple Out-of-School With Disabilities': [0],
-                'Multiple Out-of-School Without Disabilities': [1]
+                'Multiple Out-of-School Without Disabilities': [1],
+                'In-School With Disabilities': [3],
+                'In-School Without Disabilities': [4],
+                'Expelled Receiving Services SSP1': [1],
+                'Total Discipline Resolutions': [10]
             })
             kyrc24.to_csv(ky_dir / 'kyrc24.csv', index=False)
 
@@ -33,7 +37,9 @@ class TestOutOfSchoolSuspensionE2E:
                 'SCHOOL CODE': ['200'],
                 'SCHOOL NAME': ['Test 2'],
                 'DEMOGRAPHIC': ['All Students'],
-                'OUT OF SCHOOL SUSPENSION SSP3': [3]
+                'OUT OF SCHOOL SUSPENSION SSP3': [3],
+                'EXPELLED RECEIVING SERVICES SSP1': [1],
+                'IN-SCHOOL REMOVAL INSR': [2]
             })
             safe.to_csv(ky_dir / 'safe.csv', index=False)
 
@@ -41,7 +47,7 @@ class TestOutOfSchoolSuspensionE2E:
 
             out_file = proc_dir / 'out_of_school_suspension.csv'
             df = pd.read_csv(out_file)
-            assert len(df) == 8  # 7 metrics + 1 metric
+            assert len(df) == 13
             assert set(df['metric'].unique()) >= {
                 'out_of_school_suspension_count',
                 'out_of_school_suspension_single_with_disabilities_count'


### PR DESCRIPTION
## Summary
- extend numeric cleaning in `out_of_school_suspension` ETL
- emit in-school suspension, expulsion, removal and discipline resolution counts
- update suppression defaults for new metrics
- expand unit and end-to-end tests
- document the enhancement in a new journal entry

## Testing
- `python3 -m pytest tests/test_out_of_school_suspension.py -q`
- `python3 -m pytest tests/test_out_of_school_suspension_end_to_end.py -q`
- `python3 -m pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_68802e8d9f44833085ed4f7aeb1902a9