### PR TITLE
Add Kentucky Summative Assessment ETL

### DIFF
--- a/etl/kentucky_summative_assessment.py
+++ b/etl/kentucky_summative_assessment.py
@@ -1,0 +1,155 @@
+"""Kentucky Summative Assessment ETL Module
+
+Processes accountability assessment performance files and assessment performance by grade
+files to generate KPI metrics per subject and school level or grade.
+"""
+from pathlib import Path
+from typing import Dict, Any
+import pandas as pd
+import logging
+import sys
+
+etl_dir = Path(__file__).parent
+sys.path.insert(0, str(etl_dir))
+
+from base_etl import BaseETL, Config
+
+logger = logging.getLogger(__name__)
+
+
+class KentuckySummativeAssessmentETL(BaseETL):
+    """ETL module for Kentucky Summative Assessment data."""
+
+    @property
+    def module_column_mappings(self) -> Dict[str, str]:
+        return {
+            # Subject/grade/level fields
+            "Subject": "subject",
+            "SUBJECT": "subject",
+            "Grade": "grade",
+            "GRADE": "grade",
+            "LEVEL": "level",
+            # Proficiency columns
+            "Novice": "novice",
+            "NOVICE": "novice",
+            "Apprentice": "apprentice",
+            "APPRENTICE": "apprentice",
+            "Proficient": "proficient",
+            "PROFICIENT": "proficient",
+            "Distinguished": "distinguished",
+            "DISTINGUISHED": "distinguished",
+            "Proficient / Distinguished": "proficient_distinguished",
+            "PROFICIENT/DISTINGUISHED": "proficient_distinguished",
+        }
+
+    def _normalize_level(self, level: Any) -> str:
+        mapping = {
+            "ES": "elementary",
+            "MS": "middle",
+            "HS": "high",
+            "Elementary School": "elementary",
+            "Middle School": "middle",
+            "High School": "high",
+        }
+        if level is None or pd.isna(level) or level == "":
+            return "all"
+        return mapping.get(str(level), str(level).lower())
+
+    def _normalize_subject(self, subject: Any) -> str:
+        mapping = {
+            "MA": "mathematics",
+            "Mathematics": "mathematics",
+            "RD": "reading",
+            "Reading": "reading",
+            "WR": "writing",
+            "On Demand Writing": "writing",
+            "SC": "science",
+            "Science": "science",
+            "SS": "social_studies",
+            "Social Studies": "social_studies",
+            "CW": "editing_mechanics",
+            "Editing and Mechanics": "editing_mechanics",
+        }
+        if subject is None or pd.isna(subject) or subject == "":
+            return "unknown"
+        return mapping.get(str(subject), str(subject).lower().replace(" ", "_"))
+
+    def extract_metrics(self, row: pd.Series) -> Dict[str, Any]:
+        metrics: Dict[str, Any] = {}
+        subject = self._normalize_subject(row.get("subject"))
+        grade = row.get("grade")
+        level = row.get("level")
+
+        if pd.notna(grade) and grade != "":
+            suffix = self.normalize_grade_field(pd.DataFrame({"grade": [grade]}))[
+                "grade"
+            ].iloc[0]
+        else:
+            suffix = self._normalize_level(level)
+
+        score_map = {
+            "novice": row.get("novice", pd.NA),
+            "apprentice": row.get("apprentice", pd.NA),
+            "proficient": row.get("proficient", pd.NA),
+            "distinguished": row.get("distinguished", pd.NA),
+            "proficient_distinguished": row.get("proficient_distinguished", pd.NA),
+        }
+
+        for score_name, value in score_map.items():
+            if pd.notna(value):
+                metrics[f"{subject}_{score_name}_rate_{suffix}"] = value
+        return metrics
+
+    def get_suppressed_metric_defaults(self, row: pd.Series) -> Dict[str, Any]:
+        subject = self._normalize_subject(row.get("subject"))
+        grade = row.get("grade")
+        level = row.get("level")
+        if pd.notna(grade) and grade != "":
+            suffix = self.normalize_grade_field(pd.DataFrame({"grade": [grade]}))[
+                "grade"
+            ].iloc[0]
+        else:
+            suffix = self._normalize_level(level)
+        return {
+            f"{subject}_novice_rate_{suffix}": pd.NA,
+            f"{subject}_apprentice_rate_{suffix}": pd.NA,
+            f"{subject}_proficient_rate_{suffix}": pd.NA,
+            f"{subject}_distinguished_rate_{suffix}": pd.NA,
+            f"{subject}_proficient_distinguished_rate_{suffix}": pd.NA,
+        }
+
+    def standardize_missing_values(self, df: pd.DataFrame) -> pd.DataFrame:
+        df = super().standardize_missing_values(df)
+        rate_cols = [
+            c
+            for c in [
+                "novice",
+                "apprentice",
+                "proficient",
+                "distinguished",
+                "proficient_distinguished",
+            ]
+            if c in df.columns
+        ]
+        for col in rate_cols:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+            invalid = (df[col] < 0) | (df[col] > 100)
+            if invalid.any():
+                logger.warning(f"Invalid values in {col}: {invalid.sum()}")
+                df.loc[invalid, col] = pd.NA
+        return df
+
+
+def transform(raw_dir: Path, proc_dir: Path, cfg: dict) -> None:
+    etl = KentuckySummativeAssessmentETL("kentucky_summative_assessment")
+    etl.transform(raw_dir, proc_dir, cfg)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    raw_dir = Path(__file__).parent.parent / "data" / "raw"
+    proc_dir = Path(__file__).parent.parent / "data" / "processed"
+    proc_dir.mkdir(exist_ok=True)
+
+    test_config = Config(derive={"processing_date": "2025-07-22"}).dict()
+    transform(raw_dir, proc_dir, test_config)

--- a/notes/40--kentucky-summative-assessment-pipeline-implementation.md
+++ b/notes/40--kentucky-summative-assessment-pipeline-implementation.md
@@ -1,0 +1,15 @@
+# Kentucky Summative Assessment Pipeline Implementation
+
+## Date: 2025-07-22
+
+Implemented a new ETL pipeline to process Kentucky Summative Assessment files. The
+pipeline handles both the accountability files broken down by **school level** and
+the grade level assessment files. Metrics are generated for each subject and
+performance band with suffixes for the grade or school level.
+
+### Key Features
+- Subject and level normalization for historical files
+- Validation of rate columns (0-100 range)
+- Support for suppressed records with metric placeholders
+- Unit and end-to-end tests covering grade and level inputs
+

--- a/tests/test_kentucky_summative_assessment.py
+++ b/tests/test_kentucky_summative_assessment.py
@@ -1,0 +1,108 @@
+"""Unit tests for Kentucky Summative Assessment ETL"""
+import tempfile
+import shutil
+from pathlib import Path
+import pandas as pd
+from etl.kentucky_summative_assessment import (
+    KentuckySummativeAssessmentETL,
+    transform,
+)
+
+
+class TestKentuckySummativeAssessmentETL:
+    def setup_method(self):
+        self.test_dir = Path(tempfile.mkdtemp())
+        self.raw_dir = self.test_dir / "raw"
+        self.proc_dir = self.test_dir / "processed"
+        self.proc_dir.mkdir(parents=True)
+        self.sample_dir = self.raw_dir / "kentucky_summative_assessment"
+        self.sample_dir.mkdir(parents=True)
+        self.etl = KentuckySummativeAssessmentETL("kentucky_summative_assessment")
+
+    def teardown_method(self):
+        shutil.rmtree(self.test_dir)
+
+    def sample_grade_data(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "School Year": ["20232024"],
+                "County Name": ["FAYETTE"],
+                "District Name": ["Fayette County"],
+                "School Name": ["Test School"],
+                "School Code": ["165101"],
+                "Grade": ["Grade 10"],
+                "Subject": ["Mathematics"],
+                "Demographic": ["All Students"],
+                "Suppressed": ["N"],
+                "Novice": [30],
+                "Apprentice": [25],
+                "Proficient": [35],
+                "Distinguished": [10],
+                "Proficient / Distinguished": [45],
+            }
+        )
+
+    def sample_level_data(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "SCHOOL YEAR": ["20222023"],
+                "COUNTY NAME": ["FAYETTE"],
+                "DISTRICT NAME": ["Fayette County"],
+                "SCHOOL NAME": ["Test School"],
+                "SCHOOL CODE": ["165101"],
+                "LEVEL": ["HS"],
+                "SUBJECT": ["MA"],
+                "DEMOGRAPHIC": ["All Students"],
+                "SUPPRESSED": ["N"],
+                "NOVICE": [20],
+                "APPRENTICE": [30],
+                "PROFICIENT": [40],
+                "DISTINGUISHED": [10],
+                "PROFICIENT/DISTINGUISHED": [50],
+            }
+        )
+
+    def test_normalize_column_names(self):
+        df = self.sample_grade_data()
+        norm = self.etl.normalize_column_names(df)
+        assert "subject" in norm.columns
+        assert "grade" in norm.columns
+        df2 = self.sample_level_data()
+        norm2 = self.etl.normalize_column_names(df2)
+        assert "level" in norm2.columns
+        assert "subject" in norm2.columns
+
+    def test_extract_metrics_grade(self):
+        df = self.sample_grade_data()
+        df = self.etl.normalize_column_names(df)
+        df = self.etl.standardize_missing_values(df)
+        df = self.etl.normalize_grade_field(df)
+        row = df.iloc[0]
+        metrics = self.etl.extract_metrics(row)
+        assert "mathematics_novice_rate_grade_10" in metrics
+        assert metrics["mathematics_proficient_rate_grade_10"] == 35
+
+    def test_convert_to_kpi_format_level(self):
+        df = self.sample_level_data()
+        df = self.etl.normalize_column_names(df)
+        df = self.etl.standardize_missing_values(df)
+        df["source_file"] = "test.csv"
+        kpi = self.etl.convert_to_kpi_format(df, "test.csv")
+        assert not kpi.empty
+        metrics = kpi["metric"].unique().tolist()
+        assert "mathematics_novice_rate_high" in metrics
+
+    def test_full_transform(self):
+        # create sample files
+        grade_df = self.sample_grade_data()
+        level_df = self.sample_level_data()
+        grade_df.to_csv(self.sample_dir / "grade.csv", index=False)
+        level_df.to_csv(self.sample_dir / "level.csv", index=False)
+        config = {"derive": {"processing_date": "2024-07-22"}}
+        transform(self.raw_dir, self.proc_dir, config)
+        output = self.proc_dir / "kentucky_summative_assessment.csv"
+        assert output.exists()
+        out_df = pd.read_csv(output)
+        assert not out_df.empty
+        assert "mathematics_proficient_rate_grade_10" in out_df["metric"].values
+        assert "mathematics_novice_rate_high" in out_df["metric"].values

--- a/tests/test_kentucky_summative_assessment_end_to_end.py
+++ b/tests/test_kentucky_summative_assessment_end_to_end.py
@@ -1,0 +1,76 @@
+"""End-to-end tests for Kentucky Summative Assessment pipeline"""
+import tempfile
+import shutil
+from pathlib import Path
+import pandas as pd
+from etl.kentucky_summative_assessment import transform
+
+
+class TestKentuckySummativeAssessmentEndToEnd:
+    def setup_method(self):
+        self.test_dir = Path(tempfile.mkdtemp())
+        self.raw_dir = self.test_dir / "raw"
+        self.proc_dir = self.test_dir / "processed"
+        self.proc_dir.mkdir(parents=True)
+        self.sample_dir = self.raw_dir / "kentucky_summative_assessment"
+        self.sample_dir.mkdir(parents=True)
+
+    def teardown_method(self):
+        shutil.rmtree(self.test_dir)
+
+    def create_grade_file(self):
+        df = pd.DataFrame(
+            {
+                "School Year": ["20232024", "20232024"],
+                "County Name": ["FAYETTE", "FAYETTE"],
+                "District Name": ["Fayette County", "Fayette County"],
+                "School Name": ["Test School", "Test School"],
+                "School Code": ["165101", "165101"],
+                "Grade": ["Grade 10", "Grade 11"],
+                "Subject": ["Mathematics", "Reading"],
+                "Demographic": ["All Students", "All Students"],
+                "Suppressed": ["N", "Y"],
+                "Novice": [30, "*"],
+                "Apprentice": [25, "*"],
+                "Proficient": [35, "*"],
+                "Distinguished": [10, "*"],
+                "Proficient / Distinguished": [45, "*"],
+            }
+        )
+        df.to_csv(self.sample_dir / "grade.csv", index=False)
+
+    def create_level_file(self):
+        df = pd.DataFrame(
+            {
+                "SCHOOL YEAR": ["20222023"],
+                "COUNTY NAME": ["FAYETTE"],
+                "DISTRICT NAME": ["Fayette County"],
+                "SCHOOL NAME": ["Test School"],
+                "SCHOOL CODE": ["165101"],
+                "LEVEL": ["HS"],
+                "SUBJECT": ["MA"],
+                "DEMOGRAPHIC": ["All Students"],
+                "SUPPRESSED": ["N"],
+                "NOVICE": [20],
+                "APPRENTICE": [30],
+                "PROFICIENT": [40],
+                "DISTINGUISHED": [10],
+                "PROFICIENT/DISTINGUISHED": [50],
+            }
+        )
+        df.to_csv(self.sample_dir / "level.csv", index=False)
+
+    def test_pipeline_end_to_end(self):
+        self.create_grade_file()
+        self.create_level_file()
+        config = {"derive": {"processing_date": "2024-07-22"}}
+        transform(self.raw_dir, self.proc_dir, config)
+        out_file = self.proc_dir / "kentucky_summative_assessment.csv"
+        assert out_file.exists()
+        df = pd.read_csv(out_file)
+        assert not df.empty
+        assert "mathematics_novice_rate_grade_10" in df["metric"].values
+        assert "reading_novice_rate_grade_11" in df["metric"].values
+        assert "mathematics_apprentice_rate_high" in df["metric"].values
+        suppressed = df[df["suppressed"] == "Y"]
+        assert suppressed["value"].isna().all()


### PR DESCRIPTION
## Summary
- implement ETL for kentucky_summative_assessment dataset
- provide unit tests and end-to-end test
- document pipeline implementation in notes

## Testing
- `python3 -m pytest tests/test_kentucky_summative_assessment.py -v`
- `python3 -m pytest tests/test_kentucky_summative_assessment_end_to_end.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6882a72b10488330833a0b82b796fb3c