### PR TITLE
Add safe schools discipline count metrics

### DIFF
--- a/notes/40--safe-schools-discipline-kpi-expansion.md
+++ b/notes/40--safe-schools-discipline-kpi-expansion.md
@@ -1,0 +1,33 @@
+# Journal Entry 40: Safe Schools Discipline KPI Mapping Review
+
+## Objective
+Summarize how the `safe_schools_discipline` pipeline converts source columns into KPI metrics and identify potential additional metrics that could be surfaced.
+
+## Current KPI Mapping
+- Input files include:
+  - `KYRC24_SAFE_Discipline_Resolutions.csv`
+  - `KYRC24_SAFE_Legal_Sanctions.csv`
+  - Historical `safe_schools_discipline_<year>.csv`
+- `module_column_mappings` normalizes discipline resolution and legal sanction columns. Key mappings include:
+  - `Corporal Punishment (SSP5)` → `corporal_punishment_count`
+  - `Restraint (SSP7)` → `restraint_count`
+  - `Seclusion (SSP8)` → `seclusion_count`
+  - `Expelled, Not Receiving Services (SSP2)` → `expelled_not_receiving_services_count`
+  - `Expelled, Receiving Services (SSP1)` → `expelled_receiving_services_count`
+  - `In-School Removal (INSR) Or In-District Removal (INDR) >=.5` → `in_school_removal_count`
+  - `Out-Of-School Suspensions (SSP3)` → `out_of_school_suspension_count`
+  - `Removal By Hearing Officer (IAES2)` → `removal_by_hearing_officer_count`
+  - `Unilateral Removal By School Personnel (IAES1)` → `unilateral_removal_count`
+  - Legal sanction columns such as `Arrests`, `Charges`, `Civil Proceedings`, `Court Designated Worker Involvement`, `School Resource Officer Involvement` map to corresponding `_count` fields.
+- In `extract_metrics`, the pipeline calculates rate metrics for each count using the row total (`Total` or `Total Discipline Resolutions`) as the denominator.
+- Only non-zero rates are emitted, following the naming convention `{indicator}_rate`.
+- Suppressed rows output all rate metrics with `NA` values via `get_suppressed_metric_defaults`.
+
+## Potential Additional KPIs
+The source files also contain raw counts and totals that are currently only used to compute rates. Exposing these values would allow absolute comparisons alongside percentage rates. Possible new metrics include:
+- Counts for each discipline resolution and legal sanction (e.g., `restraint_count`, `arrest_count`).
+- Total discipline resolutions per demographic group (`discipline_resolutions_total_count`).
+- Totals for legal sanctions if present (`legal_sanctions_total_count`).
+
+Providing both rates and counts could help stakeholders gauge overall volume of disciplinary actions in addition to proportional impact.
+

--- a/notes/41--safe-schools-discipline-counts.md
+++ b/notes/41--safe-schools-discipline-counts.md
@@ -1,0 +1,12 @@
+# Journal Entry 41: Safe Schools Discipline Counts
+
+## Objective
+Add raw count and total metrics to the safe schools discipline pipeline.
+
+## Changes
+- Modified `extract_metrics` to output count metrics and total enrollment values for both discipline resolutions and legal sanctions.
+- Updated suppressed metric defaults to include new metrics.
+- Adjusted integration tests to validate rates separately from counts.
+- Added unit tests for count extraction and zero-total handling.
+
+Counts now accompany rate metrics, providing absolute volume alongside percentages.

--- a/tests/test_safe_schools_discipline.py
+++ b/tests/test_safe_schools_discipline.py
@@ -137,7 +137,7 @@ class TestSafeSchoolsDisciplineETL:
         })
         
         metrics = etl.extract_metrics(row)
-        
+
         assert 'restraint_rate' in metrics
         assert metrics['restraint_rate'] == 2.0
         assert 'out_of_school_suspension_rate' in metrics
@@ -148,6 +148,9 @@ class TestSafeSchoolsDisciplineETL:
         assert metrics['expelled_receiving_services_rate'] == 1.0
         assert 'unilateral_removal_rate' in metrics
         assert metrics['unilateral_removal_rate'] == 1.0
+        # Count metrics
+        assert metrics['restraint_count'] == 2
+        assert metrics['discipline_resolutions_total_count'] == 100
         
     def test_extract_metrics_kyrc24_legal(self):
         """Test metric extraction from KYRC24 legal sanctions data."""
@@ -172,6 +175,9 @@ class TestSafeSchoolsDisciplineETL:
         assert metrics['court_designated_worker_rate'] == 5.0
         assert 'school_resource_officer_rate' in metrics
         assert metrics['school_resource_officer_rate'] == 75.0
+        # Count metrics
+        assert metrics['arrest_count'] == 2
+        assert metrics['legal_sanctions_total_count'] == 20
     
     def test_extract_metrics_historical(self):
         """Test metric extraction from historical data."""
@@ -199,6 +205,8 @@ class TestSafeSchoolsDisciplineETL:
         assert metrics['restraint_rate'] == round(1/85*100, 2)
         assert 'unilateral_removal_rate' in metrics
         assert metrics['unilateral_removal_rate'] == round(1/85*100, 2)
+        assert metrics['discipline_resolutions_total_count'] == 85
+        assert metrics['restraint_count'] == 1
     
     def test_extract_metrics_zero_total(self):
         """Test metric extraction with zero total."""
@@ -212,7 +220,12 @@ class TestSafeSchoolsDisciplineETL:
         })
         
         metrics = etl.extract_metrics(row)
-        assert len(metrics) == 0  # Should return no metrics when total is 0
+        # Should return count metrics but no rates when total is 0
+        assert 'restraint_count' in metrics
+        assert metrics['restraint_count'] == 1
+        assert 'discipline_resolutions_total_count' in metrics
+        assert metrics['discipline_resolutions_total_count'] == 0
+        assert 'restraint_rate' not in metrics
     
     def test_extract_metrics_zero_counts(self):
         """Test metric extraction with zero counts."""
@@ -233,6 +246,7 @@ class TestSafeSchoolsDisciplineETL:
         assert 'in_school_removal_rate' not in metrics
         assert 'out_of_school_suspension_rate' in metrics
         assert metrics['out_of_school_suspension_rate'] == 10.0
+        assert metrics['restraint_count'] == 0
     
     def test_get_suppressed_metric_defaults(self):
         """Test suppressed metric defaults."""
@@ -247,7 +261,14 @@ class TestSafeSchoolsDisciplineETL:
             'in_school_removal_rate', 'out_of_school_suspension_rate',
             'removal_by_hearing_officer_rate', 'unilateral_removal_rate',
             'arrest_rate', 'charges_rate', 'civil_proceedings_rate',
-            'court_designated_worker_rate', 'school_resource_officer_rate'
+            'court_designated_worker_rate', 'school_resource_officer_rate',
+            'corporal_punishment_count', 'restraint_count', 'seclusion_count',
+            'expelled_not_receiving_services_count', 'expelled_receiving_services_count',
+            'in_school_removal_count', 'out_of_school_suspension_count',
+            'removal_by_hearing_officer_count', 'unilateral_removal_count',
+            'arrest_count', 'charges_count', 'civil_proceedings_count',
+            'court_designated_worker_count', 'school_resource_officer_count',
+            'discipline_resolutions_total_count', 'legal_sanctions_total_count'
         ]
         
         for metric in expected_metrics:

--- a/tests/test_safe_schools_discipline_end_to_end.py
+++ b/tests/test_safe_schools_discipline_end_to_end.py
@@ -131,7 +131,8 @@ class TestSafeSchoolsDisciplineEndToEnd:
 
         # Check data quality
         assert df_result['value'].min() >= 0
-        assert df_result['value'].max() <= 100
+        rate_values = df_result[df_result['metric'].str.contains('_rate')]['value']
+        assert rate_values.max() <= 100
         assert df_result['district'].notna().all()
         assert df_result['school_id'].notna().all()
 
@@ -239,7 +240,8 @@ class TestSafeSchoolsDisciplineEndToEnd:
 
         # Validate data quality
         assert df_result['value'].min() >= 0
-        assert df_result['value'].max() <= 100
+        rate_values = df_result[df_result['metric'].str.contains('_rate')]['value']
+        assert rate_values.max() <= 100
         assert df_result['district'].notna().all()
         assert df_result['school_id'].notna().all()
         assert df_result['metric'].notna().all()


### PR DESCRIPTION
## Summary
- extend `SafeSchoolsDisciplineETL` to output count metrics and totals
- update suppressed metric defaults to include new metrics
- adjust discipline unit tests for counts
- update end-to-end tests to validate only rate values against percent range
- add journal entry describing the changes

## Testing
- `python3 -m py_compile etl/safe_schools_discipline.py`
- `python3 -m pytest tests/test_safe_schools_discipline.py -q`
- `python3 -m pytest tests/test_safe_schools_discipline_end_to_end.py::TestSafeSchoolsDisciplineEndToEnd::test_end_to_end_kyrc24_discipline_only -q`
- `python3 -m pytest tests/test_safe_schools_discipline_end_to_end.py::TestSafeSchoolsDisciplineEndToEnd::test_end_to_end_all_files -q`
- `python3 -m pytest tests/ -q`


------
https://chatgpt.com/codex/tasks/task_e_68802f1962bc83309fcf769669995808