### PR TITLE
Add note confirming no extra readiness metrics

### DIFF
--- a/notes/40--postsecondary-readiness-kpi-expansion-review.md
+++ b/notes/40--postsecondary-readiness-kpi-expansion-review.md
@@ -1,0 +1,31 @@
+# Postsecondary Readiness KPI Expansion Review
+
+**Date:** 2025-07-23
+
+## Overview
+Review of `etl/postsecondary_readiness.py` to understand current KPI mapping and explore potential additional metrics from the raw files.
+
+## Current KPI Mapping
+- Source columns `Postsecondary Rate` or `POSTSECONDARY RATE` → metric `postsecondary_readiness_rate`.
+- Source columns `Postsecondary Rate With Bonus` or `POSTSECONDARY RATE WITH BONUS` → metric `postsecondary_readiness_rate_with_bonus`.
+- The pipeline always emits two KPI rows per source record: one for the base rate and one for the bonus rate. Suppressed rows are retained with `value=NaN`.
+- No counts or totals are currently produced—only rate metrics are extracted.
+
+## Potential Additional KPIs
+While the open datasets referenced in `data/raw/postsecondary_readiness/index.html` mention assessment scores and technical indicators, the current ETL only exposes the two readiness rates. The CSV files may include fields such as:
+- Numbers of students meeting the academic indicator
+- Numbers of students meeting the career/technical indicator
+- Total graduates or participants used as denominators
+- Specific assessment metrics (e.g., ACT benchmark met, industry certifications earned)
+
+Exposing these counts would enable calculation of readiness counts and rates by component. If available, potential KPIs might include:
+1. `postsecondary_readiness_academic_count` and `_total`
+2. `postsecondary_readiness_career_count` and `_total`
+3. Counts for ACT benchmark, dual credit, or industry certification attainment
+
+These additional metrics would complement the existing rates and provide more granular insight into how students achieve readiness.
+
+## Next Steps
+1. Inspect the raw CSV headers to confirm whether counts or component indicators are present.
+2. If so, extend `PostsecondaryReadinessETL.extract_metrics` to return these additional fields using the same KPI naming convention.
+3. Update tests and documentation to cover new metrics.

--- a/notes/41--postsecondary-readiness-kpi-data-inspection.md
+++ b/notes/41--postsecondary-readiness-kpi-data-inspection.md
@@ -1,0 +1,19 @@
+# Postsecondary Readiness KPI Data Inspection
+
+**Date:** 2025-07-24
+
+## Goal
+Review the raw postsecondary readiness files to confirm if additional metrics beyond the two readiness rates exist.
+
+## Process
+1. Installed dependencies with `pip install -e .` and `pip install requests pyyaml`.
+2. Downloaded raw files using `python3 data/prepare_kde_data.py postsecondary_readiness`.
+3. Examined the headers of `KYRC24_ACCT_Postsecondary_Readiness.csv`, `postsecondary_readiness_2023.csv`, and `postsecondary_readiness_2022.csv`.
+
+## Findings
+- Each file contains the same 17 columns.
+- Only metric fields are `Postsecondary Rate` and `Postsecondary Rate With Bonus`.
+- No counts, totals, or component-level indicators are present in these datasets.
+
+## Conclusion
+The current pipeline correctly exposes all available readiness metrics from the source files. Additional KPIs such as academic/career counts are not derivable from these CSVs without supplemental data.


### PR DESCRIPTION
## Summary
- document raw data inspection for postsecondary readiness
- verify only rate metrics are available in the source files

## Testing
- `python3 -m pytest tests/test_postsecondary_readiness.py::TestPostsecondaryReadinessETL::test_transform_2024_format -q`
- `python3 -m pytest tests/test_postsecondary_readiness.py::TestPostsecondaryReadinessHelpers::test_normalize_column_names_edge_cases -q`
- `python3 -m pytest tests/test_postsecondary_readiness.py -q`
- `python3 -m pytest tests/test_postsecondary_readiness_end_to_end.py -q`
- `python3 -m pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_68802ea0c628833098b82baecca6e653